### PR TITLE
Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,19 @@ An Ansible collection for running [Simple Server](https://github.com/simpledotor
 
 ### Add a new deployment
 
-Coming soon...
+You can add a new deployment by running the following command.
+
+```bash
+$ bin/new
+```
+
+This script will prompt you for some key information about your new deployment:
+* Deployment name
+* Deployment domain/subdomain
+* IP addresses of your servers
+
+and generate the necessary files for you. Once complete, the script will provide you with instructions on how to install
+Simple on your new servers.
 
 ### Edit vault secrets
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,4 +2,4 @@
 host_key_checking = False
 remote_user = "ubuntu"
 interpreter_python = /usr/bin/python3
-vault_identity_list = ethiopia_demo@~/.vault_password_et, ethiopia_production@~/.vault_password_et, testing@~/.vault_password_testing
+vault_identity_list = ethiopia_demo@~/.vault_password_et, ethiopia_production@~/.vault_password_et

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,4 +2,4 @@
 host_key_checking = False
 remote_user = "ubuntu"
 interpreter_python = /usr/bin/python3
-vault_identity_list = ethiopia_demo@~/.vault_password_et, ethiopia_production@~/.vault_password_et
+vault_identity_list = ethiopia_demo@~/.vault_password_et, ethiopia_production@~/.vault_password_et, testing@~/.vault_password_testing

--- a/bin/new
+++ b/bin/new
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+require 'FileUtils'
+require 'erb'
+
+def new_deployment
+  project_path = File.expand_path("..", File.dirname(__FILE__))
+  templates_path = File.expand_path("bin/templates", project_path)
+  hosts_path = File.expand_path("hosts", project_path)
+  group_vars_path = File.expand_path("group_vars", project_path)
+
+  deployment_name = get_deployment_name
+
+  inventory_template = ERB.new(File.read("#{templates_path}/inventory.erb"))
+  inventory = inventory_template.result(binding)
+  File.write("#{hosts_path}/#{deployment_name}", inventory)
+end
+
+def get_deployment_name
+  puts "Enter the name of the new deployment."
+  puts "The deployment name can only contain letters and underscores, eg: 'test_environment'."
+  print "Deployment name: "
+  deployment_name = gets.chomp
+
+  if deployment_name.match?( /[^a-zA-Z_]/ )
+    puts "The deployment name can only contain letters and underscores. Aborting..."
+    abort
+  end
+
+  if File.exists?("hosts/#{deployment_name}")
+    puts "Deployment name #{deployment_name} already exists. Aborting..."
+    abort
+  end
+
+  deployment_name
+end
+
+new_deployment

--- a/bin/new
+++ b/bin/new
@@ -12,6 +12,15 @@ def input(label, default: nil)
   input_string
 end
 
+def input_list(label, default: nil)
+  print "#{label}: "
+  input_string = gets.chomp
+
+  return default if default && input_string.empty?
+
+  input_string.split(",").map!(&:strip)
+end
+
 # ----------------------------
 # Fetch deployment information
 # ----------------------------
@@ -43,8 +52,8 @@ puts "If you don't have the IP addresses yet, you can leave these fields blank, 
 
 postgres_primary = input("Primary postgres database", default: "change-me")
 postgres_secondary = input("Secondary postgres database (hot standby follower)", default: "change-me")
-web_servers = input("Web servers (comma-separated)", default: "change-me,change-me").split(",").map!(&:strip)
-sidekiq_servers = input("Sidekiq background job servers (comma-separated)", default: "change-me,change-me").split(",").map!(&:strip)
+web_servers = input_list("Web servers (comma-separated)", default: ["change-me", "change-me"])
+sidekiq_servers = input_list("Sidekiq background job servers (comma-separated)", default: ["change-me", "change-me"])
 redis_primary = input("Primary Redis cache", default: "change-me")
 redis_secondary = input("Secondary Redis cache (hot standby follower)", default: "change-me")
 prometheus = input("Prometheus (system monitoring tool)", default: "change-me")

--- a/bin/new
+++ b/bin/new
@@ -13,7 +13,7 @@ def input(label, default: nil)
 end
 
 def input_list(label, default: nil)
-  print "#{label}: "
+  print "#{label} (comma-separated list): "
   input_string = gets.chomp
 
   return default if default && input_string.empty?
@@ -52,8 +52,8 @@ puts "If you don't have the IP addresses yet, you can leave these fields blank, 
 
 postgres_primary = input("Primary postgres database", default: "change-me")
 postgres_secondary = input("Secondary postgres database (hot standby follower)", default: "change-me")
-web_servers = input_list("Web servers (comma-separated)", default: ["change-me", "change-me"])
-sidekiq_servers = input_list("Sidekiq background job servers (comma-separated)", default: ["change-me", "change-me"])
+web_servers = input_list("Web servers", default: ["change-me", "change-me"])
+sidekiq_servers = input_list("Sidekiq background job servers", default: ["change-me", "change-me"])
 redis_primary = input("Primary Redis cache", default: "change-me")
 redis_secondary = input("Secondary Redis cache (hot standby follower)", default: "change-me")
 prometheus = input("Prometheus (system monitoring tool)", default: "change-me")

--- a/bin/new
+++ b/bin/new
@@ -98,7 +98,7 @@ File.write("#{project_path}/ansible.cfg", ansible_config.join)
 puts
 puts "#{deployment_name} deployment environment initialized!"
 puts "To finish setup, follow these steps"
-puts "- Enter your servers' IP addresses into the Ansible inventory file hosts/#{deployment_name}"
+puts "- If you skipped entering any IP addresses, enter them into your Ansible inventory file hosts/#{deployment_name}"
 puts "- Configure your instance's variables in group_vars/#{deployment_name}/vars.yml"
 puts "- Configure your instance's secrets in group_vars/#{deployment_name}/vault.yml.decrypted"
 puts "- Create an Ansible vault password and place it in a file at ~/.vault_password_#{deployment_name}"

--- a/bin/new
+++ b/bin/new
@@ -3,11 +3,22 @@ require 'fileutils'
 require 'erb'
 require 'securerandom'
 
+def input(label, default: nil)
+  print "#{label}: "
+  input_string = gets.chomp
+
+  return default if default && input_string.empty?
+
+  input_string
+end
+
+# ----------------------------
+# Fetch deployment information
+# ----------------------------
 # Deployment name
 puts "Enter the name of the new deployment."
 puts "The deployment name can only contain letters and underscores, eg: 'test_environment'."
-print "Deployment name: "
-deployment_name = gets.chomp
+deployment_name = input("Deployment name")
 
 if deployment_name.match?( /[^a-zA-Z_]/ )
   puts "The deployment name can only contain letters and underscores. Aborting..."
@@ -20,11 +31,29 @@ if File.exists?("hosts/#{deployment_name}")
 end
 
 # Domain
+puts
 puts "Enter the domain or subdomain on which you'd like to host your Simple server instance"
 puts "Eg. api.simple.org"
-print "Domain/Subdomain: "
-domain = gets.chomp
+domain = input("Domain/Subdomain")
 
+# IP addresses
+puts
+puts "Enter the public IP addresses of the servers or VMs that will host the following services."
+puts "If you don't have the IP addresses yet, you can leave these fields blank, and configure them later."
+
+postgres_primary = input("Primary postgres database", default: "change-me")
+postgres_secondary = input("Secondary postgres database (hot standby follower)", default: "change-me")
+web_servers = input("Web servers (comma-separated)", default: "change-me,change-me").split(",").map!(&:strip)
+sidekiq_servers = input("Sidekiq background job servers (comma-separated)", default: "change-me,change-me").split(",").map!(&:strip)
+redis_primary = input("Primary Redis cache", default: "change-me")
+redis_secondary = input("Secondary Redis cache (hot standby follower)", default: "change-me")
+prometheus = input("Prometheus (system monitoring tool)", default: "change-me")
+grafana = input("Grafana (dashboards for viewing Prometheus data)", default: "change-me")
+storage = input("Storage of application logs, audit logs, and database backups", default: "change-me")
+load_balancing = input("Load balancer (this server will be the entry point for all incoming web traffic)", default: "change-me")
+# ----------------------------
+# Set up deployment files
+# ----------------------------
 project_path = File.expand_path("..", File.dirname(__FILE__))
 templates_path = File.expand_path("bin/templates", project_path)
 hosts_path = File.expand_path("hosts", project_path)
@@ -63,7 +92,9 @@ ansible_config[vault_identity_index] = "vault_identity_list = #{vault_identities
 
 File.write("#{project_path}/ansible.cfg", ansible_config.join)
 
-# Next steps
+# ----------------------------
+# Print next steps
+# ----------------------------
 puts
 puts "#{deployment_name} deployment environment initialized!"
 puts "To finish setup, follow these steps"

--- a/bin/new
+++ b/bin/new
@@ -63,6 +63,7 @@ group_vars_path = File.expand_path("group_vars/#{deployment_name}", project_path
 inventory_template = ERB.new(File.read("#{templates_path}/inventory.erb"))
 inventory = inventory_template.result(binding)
 File.write("#{hosts_path}/#{deployment_name}", inventory)
+puts "Created #{hosts_path}/#{deployment_name}..."
 
 # Group vars directory
 FileUtils.mkdir(group_vars_path)
@@ -71,12 +72,14 @@ FileUtils.mkdir(group_vars_path)
 vars_template = ERB.new(File.read("#{templates_path}/vars.yml.erb"))
 vars = vars_template.result(binding)
 File.write("#{group_vars_path}/vars.yml", vars)
+puts "Created #{group_vars_path}/vars.yml..."
 
 # Vault
 secret_key_base = SecureRandom.hex(128)
 vault_template = ERB.new(File.read("#{templates_path}/vault.yml.decrypted.erb"))
 vault = vault_template.result(binding)
 File.write("#{group_vars_path}/vault.yml.decrypted", vault)
+puts "Created #{group_vars_path}/vault.yml.decrypted..."
 
 # Ansible vault identity list
 # Parse the ansible vault identity list
@@ -91,6 +94,8 @@ vault_identities.push("#{deployment_name}@~/.vault_password_#{deployment_name}")
 ansible_config[vault_identity_index] = "vault_identity_list = #{vault_identities.join(", ")}"
 
 File.write("#{project_path}/ansible.cfg", ansible_config.join)
+puts "Updated #{project_path}/ansible.cfg..."
+
 
 # ----------------------------
 # Print next steps

--- a/bin/new
+++ b/bin/new
@@ -29,6 +29,20 @@ def new_deployment
   vault_template = ERB.new(File.read("#{templates_path}/vault.yml.decrypted.erb"))
   vault = vault_template.result(binding)
   File.write("#{group_vars_path}/vault.yml.decrypted", vault)
+
+  # Ansible vault list
+  # Parse the ansible vault identity list
+  #    vault_identity_list = id@path, id@path
+  # into a list of vault identities and add a new identity to the end
+  ansible_config = File.readlines("#{project_path}/ansible.cfg")
+  vault_identity_index = ansible_config.index {|x| x.start_with?("vault_identity_list")}
+  vault_identity_list = ansible_config[vault_identity_index].split("=").last
+  vault_identities = vault_identity_list.split(",").map!(&:strip)
+  vault_identities.push("#{deployment_name}@~/.vault_password_#{deployment_name}")
+
+  ansible_config[vault_identity_index] = "vault_identity_list = #{vault_identities.join(", ")}"
+
+  File.write("#{project_path}/ansible.cfg", ansible_config.join("\n"))
 end
 
 def get_deployment_name

--- a/bin/new
+++ b/bin/new
@@ -1,67 +1,76 @@
 #!/usr/bin/env ruby
-require 'FileUtils'
+require 'fileutils'
 require 'erb'
 require 'securerandom'
 
-def new_deployment
-  deployment_name = get_deployment_name
+# Deployment name
+puts "Enter the name of the new deployment."
+puts "The deployment name can only contain letters and underscores, eg: 'test_environment'."
+print "Deployment name: "
+deployment_name = gets.chomp
 
-  project_path = File.expand_path("..", File.dirname(__FILE__))
-  templates_path = File.expand_path("bin/templates", project_path)
-  hosts_path = File.expand_path("hosts", project_path)
-  group_vars_path = File.expand_path("group_vars/#{deployment_name}", project_path)
-
-  # Ansible inventory file
-  inventory_template = ERB.new(File.read("#{templates_path}/inventory.erb"))
-  inventory = inventory_template.result(binding)
-  File.write("#{hosts_path}/#{deployment_name}", inventory)
-
-  # Group vars directory
-  FileUtils.mkdir(group_vars_path)
-
-  # Vars
-  vars_template = ERB.new(File.read("#{templates_path}/vars.yml.erb"))
-  vars = vars_template.result(binding)
-  File.write("#{group_vars_path}/vars.yml", vars)
-
-  # Vault
-  secret_key_base = SecureRandom.hex(128)
-  vault_template = ERB.new(File.read("#{templates_path}/vault.yml.decrypted.erb"))
-  vault = vault_template.result(binding)
-  File.write("#{group_vars_path}/vault.yml.decrypted", vault)
-
-  # Ansible vault list
-  # Parse the ansible vault identity list
-  #    vault_identity_list = id@path, id@path
-  # into a list of vault identities and add a new identity to the end
-  ansible_config = File.readlines("#{project_path}/ansible.cfg")
-  vault_identity_index = ansible_config.index {|x| x.start_with?("vault_identity_list")}
-  vault_identity_list = ansible_config[vault_identity_index].split("=").last
-  vault_identities = vault_identity_list.split(",").map!(&:strip)
-  vault_identities.push("#{deployment_name}@~/.vault_password_#{deployment_name}")
-
-  ansible_config[vault_identity_index] = "vault_identity_list = #{vault_identities.join(", ")}"
-
-  File.write("#{project_path}/ansible.cfg", ansible_config.join("\n"))
+if deployment_name.match?( /[^a-zA-Z_]/ )
+  puts "The deployment name can only contain letters and underscores. Aborting..."
+  abort
 end
 
-def get_deployment_name
-  puts "Enter the name of the new deployment."
-  puts "The deployment name can only contain letters and underscores, eg: 'test_environment'."
-  print "Deployment name: "
-  deployment_name = gets.chomp
-
-  if deployment_name.match?( /[^a-zA-Z_]/ )
-    puts "The deployment name can only contain letters and underscores. Aborting..."
-    abort
-  end
-
-  if File.exists?("hosts/#{deployment_name}")
-    puts "Deployment name #{deployment_name} already exists. Aborting..."
-    abort
-  end
-
-  deployment_name
+if File.exists?("hosts/#{deployment_name}")
+  puts "Deployment name #{deployment_name} already exists. Aborting..."
+  abort
 end
 
-new_deployment
+# Domain
+puts "Enter the domain or subdomain on which you'd like to host your Simple server instance"
+puts "Eg. api.simple.org"
+print "Domain/Subdomain: "
+domain = gets.chomp
+
+project_path = File.expand_path("..", File.dirname(__FILE__))
+templates_path = File.expand_path("bin/templates", project_path)
+hosts_path = File.expand_path("hosts", project_path)
+group_vars_path = File.expand_path("group_vars/#{deployment_name}", project_path)
+
+# Ansible inventory file
+inventory_template = ERB.new(File.read("#{templates_path}/inventory.erb"))
+inventory = inventory_template.result(binding)
+File.write("#{hosts_path}/#{deployment_name}", inventory)
+
+# Group vars directory
+FileUtils.mkdir(group_vars_path)
+
+# Vars
+vars_template = ERB.new(File.read("#{templates_path}/vars.yml.erb"))
+vars = vars_template.result(binding)
+File.write("#{group_vars_path}/vars.yml", vars)
+
+# Vault
+secret_key_base = SecureRandom.hex(128)
+vault_template = ERB.new(File.read("#{templates_path}/vault.yml.decrypted.erb"))
+vault = vault_template.result(binding)
+File.write("#{group_vars_path}/vault.yml.decrypted", vault)
+
+# Ansible vault identity list
+# Parse the ansible vault identity list
+#    vault_identity_list = id@path, id@path
+# into a list of vault identities and add a new identity to the end
+ansible_config = File.readlines("#{project_path}/ansible.cfg")
+vault_identity_index = ansible_config.index {|x| x.start_with?("vault_identity_list")}
+vault_identity_list = ansible_config[vault_identity_index].split("=").last
+vault_identities = vault_identity_list.split(",").map!(&:strip)
+vault_identities.push("#{deployment_name}@~/.vault_password_#{deployment_name}")
+
+ansible_config[vault_identity_index] = "vault_identity_list = #{vault_identities.join(", ")}"
+
+File.write("#{project_path}/ansible.cfg", ansible_config.join)
+
+# Next steps
+puts
+puts "#{deployment_name} deployment environment initialized!"
+puts "To finish setup, follow these steps"
+puts "- Enter your servers' IP addresses into the Ansible inventory file hosts/#{deployment_name}"
+puts "- Configure your instance's variables in group_vars/#{deployment_name}/vars.yml"
+puts "- Configure your instance's secrets in group_vars/#{deployment_name}/vault.yml.decrypted"
+puts "- Create an Ansible vault password and place it in a file at ~/.vault_password_#{deployment_name}"
+puts "- Create your vault file by running `make encrypt hosts=#{deployment_name}`"
+puts
+puts "And you're done! You can then deploy Simple onto your servers with `make all`"

--- a/bin/new
+++ b/bin/new
@@ -24,18 +24,19 @@ end
 # ----------------------------
 # Fetch deployment information
 # ----------------------------
+params = {}
 # Deployment name
 puts "Enter the name of the new deployment."
 puts "The deployment name can only contain letters and underscores, eg: 'test_environment'."
-deployment_name = input("Deployment name")
+params[:deployment_name] = input("Deployment name")
 
-if deployment_name.match?( /[^a-zA-Z_]/ )
+if params[:deployment_name].match?( /[^a-zA-Z_]/ )
   puts "The deployment name can only contain letters and underscores. Aborting..."
   abort
 end
 
-if File.exists?("hosts/#{deployment_name}")
-  puts "Deployment name #{deployment_name} already exists. Aborting..."
+if File.exists?("hosts/#{params[:deployment_name]}")
+  puts "Deployment name #{params[:deployment_name]} already exists. Aborting..."
   abort
 end
 
@@ -43,50 +44,52 @@ end
 puts
 puts "Enter the domain or subdomain on which you'd like to host your Simple server instance"
 puts "Eg. api.simple.org"
-domain = input("Domain/Subdomain")
+params[:domain] = input("Domain/Subdomain")
 
 # IP addresses
 puts
 puts "Enter the public IP addresses of the servers or VMs that will host the following services."
 puts "If you don't have the IP addresses yet, you can leave these fields blank, and configure them later."
 
-postgres_primary = input("Primary postgres database", default: "change-me")
-postgres_secondary = input("Secondary postgres database (hot standby follower)", default: "change-me")
-web_servers = input_list("Web servers", default: ["change-me", "change-me"])
-sidekiq_servers = input_list("Sidekiq background job servers", default: ["change-me", "change-me"])
-redis_primary = input("Primary Redis cache", default: "change-me")
-redis_secondary = input("Secondary Redis cache (hot standby follower)", default: "change-me")
-prometheus = input("Prometheus (system monitoring tool)", default: "change-me")
-grafana = input("Grafana (dashboards for viewing Prometheus data)", default: "change-me")
-storage = input("Storage of application logs, audit logs, and database backups", default: "change-me")
-load_balancing = input("Load balancer (this server will be the entry point for all incoming web traffic)", default: "change-me")
+params[:postgres_primary] = input("Primary postgres database", default: "change-me")
+params[:postgres_secondary] = input("Secondary postgres database (hot standby follower)", default: "change-me")
+params[:web_servers] = input_list("Web servers", default: ["change-me", "change-me"])
+params[:sidekiq_servers] = input_list("Sidekiq background job servers", default: ["change-me", "change-me"])
+params[:redis_primary] = input("Primary Redis cache", default: "change-me")
+params[:redis_secondary] = input("Secondary Redis cache (hot standby follower)", default: "change-me")
+params[:prometheus] = input("Prometheus (system monitoring tool)", default: "change-me")
+params[:grafana] = input("Grafana (dashboards for viewing Prometheus data)", default: "change-me")
+params[:storage] = input("Storage of application logs, audit logs, and database backups", default: "change-me")
+params[:load_balancing] = input("Load balancer (this server will be the entry point for all incoming web traffic)", default: "change-me")
+
 # ----------------------------
 # Set up deployment files
 # ----------------------------
 project_path = File.expand_path("..", File.dirname(__FILE__))
 templates_path = File.expand_path("bin/templates", project_path)
 hosts_path = File.expand_path("hosts", project_path)
-group_vars_path = File.expand_path("group_vars/#{deployment_name}", project_path)
+group_vars_path = File.expand_path("group_vars/#{params[:deployment_name]}", project_path)
+puts
 
 # Ansible inventory file
 inventory_template = ERB.new(File.read("#{templates_path}/inventory.erb"))
-inventory = inventory_template.result(binding)
-File.write("#{hosts_path}/#{deployment_name}", inventory)
-puts "Created #{hosts_path}/#{deployment_name}..."
+inventory = inventory_template.result_with_hash(params)
+File.write("#{hosts_path}/#{params[:deployment_name]}", inventory)
+puts "Created #{hosts_path}/#{params[:deployment_name]}..."
 
 # Group vars directory
 FileUtils.mkdir(group_vars_path)
 
 # Vars
 vars_template = ERB.new(File.read("#{templates_path}/vars.yml.erb"))
-vars = vars_template.result(binding)
+vars = vars_template.result_with_hash(params)
 File.write("#{group_vars_path}/vars.yml", vars)
 puts "Created #{group_vars_path}/vars.yml..."
 
 # Vault
 secret_key_base = SecureRandom.hex(128)
 vault_template = ERB.new(File.read("#{templates_path}/vault.yml.decrypted.erb"))
-vault = vault_template.result(binding)
+vault = vault_template.result_with_hash(params)
 File.write("#{group_vars_path}/vault.yml.decrypted", vault)
 puts "Created #{group_vars_path}/vault.yml.decrypted..."
 
@@ -98,7 +101,7 @@ ansible_config = File.readlines("#{project_path}/ansible.cfg")
 vault_identity_index = ansible_config.index {|x| x.start_with?("vault_identity_list")}
 vault_identity_list = ansible_config[vault_identity_index].split("=").last
 vault_identities = vault_identity_list.split(",").map!(&:strip)
-vault_identities.push("#{deployment_name}@~/.vault_password_#{deployment_name}")
+vault_identities.push("#{params[:deployment_name]}@~/.vault_password_#{params[:deployment_name]}")
 
 ansible_config[vault_identity_index] = "vault_identity_list = #{vault_identities.join(", ")}"
 
@@ -110,12 +113,12 @@ puts "Updated #{project_path}/ansible.cfg..."
 # Print next steps
 # ----------------------------
 puts
-puts "#{deployment_name} deployment environment initialized!"
+puts "#{params[:deployment_name]} deployment environment initialized!"
 puts "To finish setup, follow these steps"
-puts "- If you skipped entering any IP addresses, enter them into your Ansible inventory file hosts/#{deployment_name}"
-puts "- Configure your instance's variables in group_vars/#{deployment_name}/vars.yml"
-puts "- Configure your instance's secrets in group_vars/#{deployment_name}/vault.yml.decrypted"
-puts "- Create an Ansible vault password and place it in a file at ~/.vault_password_#{deployment_name}"
-puts "- Create your vault file by running `make encrypt hosts=#{deployment_name}`"
+puts "- If you skipped entering any IP addresses, enter them into your Ansible inventory file hosts/#{params[:deployment_name]}"
+puts "- Configure your instance's variables in group_vars/#{params[:deployment_name]}/vars.yml"
+puts "- Configure your instance's secrets in group_vars/#{params[:deployment_name]}/vault.yml.decrypted"
+puts "- Create an Ansible vault password and place it in a file at ~/.vault_password_#{params[:deployment_name]}"
+puts "- Create your vault file by running `make encrypt hosts=#{params[:deployment_name]}`"
 puts
-puts "And you're done! You can then deploy Simple onto your servers with `make all hosts=#{deployment_name}`"
+puts "And you're done! You can then deploy Simple onto your servers with `make all hosts=#{params[:deployment_name]}`"

--- a/bin/new
+++ b/bin/new
@@ -62,6 +62,12 @@ params[:grafana] = input("Grafana (dashboards for viewing Prometheus data)", def
 params[:storage] = input("Storage of application logs, audit logs, and database backups", default: "change-me")
 params[:load_balancing] = input("Load balancer (this server will be the entry point for all incoming web traffic)", default: "change-me")
 
+# Ansible vault password
+puts
+puts "Would you like to generate an Ansible vault password for this deployment? Select No if you already have an Ansible"
+puts "vault password that you plan to use"
+create_ansible_vault_password = input("Generate Ansible vault password? (y/N)") == "y"
+
 # ----------------------------
 # Set up deployment files
 # ----------------------------
@@ -97,17 +103,21 @@ puts "Created #{group_vars_path}/vault.yml.decrypted..."
 # Parse the ansible vault identity list
 #    vault_identity_list = id@path, id@path
 # into a list of vault identities and add a new identity to the end
+vault_password_path = "~/.vault_password_#{params[:deployment_name]}"
 ansible_config = File.readlines("#{project_path}/ansible.cfg")
 vault_identity_index = ansible_config.index {|x| x.start_with?("vault_identity_list")}
 vault_identity_list = ansible_config[vault_identity_index].split("=").last
 vault_identities = vault_identity_list.split(",").map!(&:strip)
-vault_identities.push("#{params[:deployment_name]}@~/.vault_password_#{params[:deployment_name]}")
+vault_identities.push("#{params[:deployment_name]}@#{vault_password_path}")
 
 ansible_config[vault_identity_index] = "vault_identity_list = #{vault_identities.join(", ")}"
 
 File.write("#{project_path}/ansible.cfg", ansible_config.join)
 puts "Updated #{project_path}/ansible.cfg..."
 
+# Ansible vault password
+File.write(File.expand_path(vault_password_path), SecureRandom.alphanumeric(256)) if create_ansible_vault_password
+puts "Created #{File.expand_path(vault_password_path)}..."
 
 # ----------------------------
 # Print next steps
@@ -118,7 +128,7 @@ puts "To finish setup, follow these steps"
 puts "- If you skipped entering any IP addresses, enter them into your Ansible inventory file hosts/#{params[:deployment_name]}"
 puts "- Configure your instance's variables in group_vars/#{params[:deployment_name]}/vars.yml"
 puts "- Configure your instance's secrets in group_vars/#{params[:deployment_name]}/vault.yml.decrypted"
-puts "- Create an Ansible vault password and place it in a file at ~/.vault_password_#{params[:deployment_name]}"
+puts "- Create an Ansible vault password and place it in a file at ~/.vault_password_#{params[:deployment_name]}" unless create_ansible_vault_password
 puts "- Create your vault file by running `make encrypt hosts=#{params[:deployment_name]}`"
 puts
 puts "And you're done! You can then deploy Simple onto your servers with `make all hosts=#{params[:deployment_name]}`"

--- a/bin/new
+++ b/bin/new
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'FileUtils'
 require 'erb'
+require 'securerandom'
 
 def new_deployment
   deployment_name = get_deployment_name
@@ -22,6 +23,12 @@ def new_deployment
   vars_template = ERB.new(File.read("#{templates_path}/vars.yml.erb"))
   vars = vars_template.result(binding)
   File.write("#{group_vars_path}/vars.yml", vars)
+
+  # Vault
+  secret_key_base = SecureRandom.hex(128)
+  vault_template = ERB.new(File.read("#{templates_path}/vault.yml.decrypted.erb"))
+  vault = vault_template.result(binding)
+  File.write("#{group_vars_path}/vault.yml.decrypted", vault)
 end
 
 def get_deployment_name

--- a/bin/new
+++ b/bin/new
@@ -3,16 +3,25 @@ require 'FileUtils'
 require 'erb'
 
 def new_deployment
+  deployment_name = get_deployment_name
+
   project_path = File.expand_path("..", File.dirname(__FILE__))
   templates_path = File.expand_path("bin/templates", project_path)
   hosts_path = File.expand_path("hosts", project_path)
-  group_vars_path = File.expand_path("group_vars", project_path)
+  group_vars_path = File.expand_path("group_vars/#{deployment_name}", project_path)
 
-  deployment_name = get_deployment_name
-
+  # Ansible inventory file
   inventory_template = ERB.new(File.read("#{templates_path}/inventory.erb"))
   inventory = inventory_template.result(binding)
   File.write("#{hosts_path}/#{deployment_name}", inventory)
+
+  # Group vars directory
+  FileUtils.mkdir(group_vars_path)
+
+  # Vars
+  vars_template = ERB.new(File.read("#{templates_path}/vars.yml.erb"))
+  vars = vars_template.result(binding)
+  File.write("#{group_vars_path}/vars.yml", vars)
 end
 
 def get_deployment_name

--- a/bin/templates/inventory.erb
+++ b/bin/templates/inventory.erb
@@ -1,0 +1,56 @@
+[postgres_primary]
+change-me replication_role=primary
+
+[postgres_secondary]
+change-me replication_role=replica
+
+[webservers]
+change-me
+change-me
+
+[sidekiq]
+change-me
+change-me
+
+[redis_primary]
+change-me
+
+[redis_secondary]
+change-me
+
+[prometheus]
+change-me
+
+[grafana]
+change-me
+
+[storage]
+change-me
+
+[load_balancing]
+change-me
+
+# Server groups. You do not need to change them.
+[<%= deployment_name %>:children]
+servers
+postgres
+redis
+monitoring
+storage
+load_balancing
+
+[postgres:children]
+postgres_primary
+postgres_secondary
+
+[servers:children]
+webservers
+sidekiq
+
+[redis:children]
+redis_primary
+redis_secondary
+
+[monitoring:children]
+prometheus
+grafana

--- a/bin/templates/inventory.erb
+++ b/bin/templates/inventory.erb
@@ -1,34 +1,36 @@
 [postgres_primary]
-change-me replication_role=primary
+<%= postgres_primary %> replication_role=primary
 
 [postgres_secondary]
-change-me replication_role=replica
+<%= postgres_secondary %> replication_role=replica
 
 [webservers]
-change-me
-change-me
+<% web_servers.each do |server| %>
+<%= server %>
+<% end %>
 
 [sidekiq]
-change-me
-change-me
+<% sidekiq_servers.each do |server| %>
+<%= server %>
+<% end %>
 
 [redis_primary]
-change-me
+<%= redis_primary %>
 
 [redis_secondary]
-change-me
+<%= redis_secondary %>
 
 [prometheus]
-change-me
+<%= prometheus %>
 
 [grafana]
-change-me
+<%= grafana %>
 
 [storage]
-change-me
+<%= storage %>
 
 [load_balancing]
-change-me
+<%= load_balancing %>
 
 # Server groups. You do not need to change them.
 [<%= deployment_name %>:children]

--- a/bin/templates/vars.yml.erb
+++ b/bin/templates/vars.yml.erb
@@ -23,7 +23,7 @@ deploy_env: "<%= deployment_name %>"
 # domain_name
 # The domain or subdomain that the deployment will be hosted at
 # eg. "demo.simple.org"
-domain_name:
+domain_name: "<%= domain %>"
 
 # simple_app_signature
 # The Simple android app signature. It is used to allow devices to link OTP SMSs with the Simple app automatically.

--- a/bin/templates/vars.yml.erb
+++ b/bin/templates/vars.yml.erb
@@ -1,0 +1,38 @@
+---
+# analytics_dashboard_cache_ttl
+# The amount of time that Simple's realtime reports are cached, in seconds. Set this lower to increase the refresh
+# rate of some reports in the dashboard.
+analytics_dashboard_cache_ttl: 60
+
+# app_env
+# The environment type of the deployment. The app_env is used to appropriately tag APM metrics and error instrumentation
+# eg. "demo" or "production"
+app_env:
+
+# default_country
+# The country that the deployment is in. Several features of the dashboard, like address labels, are configured based on
+# the default_country.
+# Accepted values: "IN", "BD", "ET", "LK"
+default_country:
+
+# deploy_env
+# A unique name for the deployment
+# eg. "ethiopia-demo"
+deploy_env: "<%= deployment_name %>"
+
+# domain_name
+# The domain or subdomain that the deployment will be hosted at
+# eg. "demo.simple.org"
+domain_name:
+
+# simple_app_signature
+# The Simple android app signature. It is used to allow devices to link OTP SMSs with the Simple app automatically.
+simple_app_signature: mLvW4P10znH
+
+# ssh_keys
+# A list of SSH keys of developers that require access to the deployment servers.
+# eg.
+# ssh_keys:
+#   - ssh-rsa AAAAB.....
+#   - ssh-ed25519 AAAAC.....
+ssh_keys:

--- a/bin/templates/vault.yml.decrypted.erb
+++ b/bin/templates/vault.yml.decrypted.erb
@@ -1,0 +1,97 @@
+# Alertmanager Slack API URL
+# Slack webhook to send alerts to in case of downtime or other incidents configured in AlertManager
+alertmanager_slack_api_url:
+
+# Database
+# Credentials for the Simple Server database
+# Choose any username and password when setting up a new deployment. Do not change these credentials after initial
+# deployment.
+database:
+  username:
+  password:
+
+# Datadog
+# Datadog API key, used to send application metrics to Datadog (https://www.datadoghq.com/)
+datadog_api_key:
+
+# DHIS2
+# Optional
+# If you wish to integrate Simple with DHIS2, configure the URL of your DHIS2 server, as well as the username and
+# password of an authorized user. When left blank, nothing will break. Simple server will simply not attempt to send any
+# data to DHIS2
+dhis2:
+  url: ""
+  username: ""
+  password: ""
+  version: "2.28"  # This is a hack because the dhis2 gem only goes to 2.28
+
+# Exotel
+# Applicable in India only
+# Exotel credentials, used to place secure calls
+exotel:
+  sid:
+  token:
+  virtual_number:
+
+# Monitoring Dashboard Password
+# Password to access the following monitoring dashboards
+# * Prometheus: Accessible at <your_domain>/prometheus
+# * Grafana: Accessible at <your_domain>/grafana
+# * Alertmanager: Accessible at <your_domain>/alertmanager
+#
+# The username for these dashboards is "admin"
+monitoring_dashboard_password:
+
+# Secret Key Base
+# Rails secret key base, used by Rails to encrypt sensitive information like session cookies, application secrets, etc.
+# Create a new secret_key_base when setting up a new deployment. A 128 character hexadecimal key is a good format.
+secret_key_base: <%= secret_key_base %>
+
+# Sendgrid
+# Credentials for Sendgrid (https://sendgrid.com/), used by Simple server to send emails to users. Emails include:
+# * Reports and downloads
+# * Password reset emails
+sendgrid:
+  username:
+  password:
+
+# Sentry
+# Credentials for Sentry (https://sentry.io/), used for error monitoring
+sentry:
+  dsn:
+  security_reporting_header:
+
+# Twilio
+# Credentials for Twilio (https://twilio.com/), used to send SMSs to patients and users. SMSs include
+# * Patient reminders to return to care
+# * User sign-in OTPs
+twilio:
+  # Primary credentials
+  account_sid:
+  auth_token:
+  phone_number:
+  # Twilio Sandbox credentials, used for testing
+  test_account_sid:
+  test_auth_token:
+
+# SSL Certificates
+# SSL certificates to be installed on the servers. If the deployment is accessible through more than one domain,
+# multiple SSL certificates can be configured here. The format for configuring the certificates is as follows. For each
+# domain, you will need to provide the full certificate chain and the private key:
+# ssl_cert_files:
+#   demo.simple.org:
+#     certificate_chain:
+#       -----BEGIN CERTIFICATE-----
+#       <certificate>
+#       -----END CERTIFICATE-----
+#       -----BEGIN CERTIFICATE-----
+#       <another certificate in the chain>
+#       -----END CERTIFICATE-----
+#     private_key:
+#       -----BEGIN PRIVATE KEY-----
+#       <private key>
+#       -----END PRIVATE KEY-----
+#   test.simple.org:
+#     certificate_chain:
+#     private_key:
+ssl_cert_files:

--- a/bin/templates/vault.yml.decrypted.erb
+++ b/bin/templates/vault.yml.decrypted.erb
@@ -95,3 +95,8 @@ twilio:
 #     certificate_chain:
 #     private_key:
 ssl_cert_files:
+  <%= domain %>:
+    certificate_chain:
+      # Enter your full certificate chain here
+    private_key:
+      # Enter your private key here

--- a/hosts/ethiopia_demo
+++ b/hosts/ethiopia_demo
@@ -1,24 +1,8 @@
-[ethiopia_demo:children]
-servers
-postgres
-redis
-monitoring
-storage
-load_balancing
-
-[postgres:children]
-postgres_primary
-postgres_secondary
-
 [postgres_primary]
 167.71.226.153 replication_role=primary
 
 [postgres_secondary]
 157.245.99.197 replication_role=replica
-
-[servers:children]
-webservers
-sidekiq
 
 [webservers]
 167.71.226.153
@@ -28,19 +12,11 @@ sidekiq
 167.71.226.153
 157.245.99.197
 
-[redis:children]
-redis_primary
-redis_secondary
-
 [redis_primary]
 167.71.226.153
 
 [redis_secondary]
 157.245.99.197
-
-[monitoring:children]
-prometheus
-grafana
 
 [prometheus]
 167.71.226.153
@@ -54,3 +30,28 @@ grafana
 [load_balancing]
 167.71.226.153
 157.245.99.197
+
+# Server groups. You do not need to change them.
+[ethiopia_demo:children]
+servers
+postgres
+redis
+monitoring
+storage
+load_balancing
+
+[postgres:children]
+postgres_primary
+postgres_secondary
+
+[servers:children]
+webservers
+sidekiq
+
+[redis:children]
+redis_primary
+redis_secondary
+
+[monitoring:children]
+prometheus
+grafana

--- a/hosts/ethiopia_production
+++ b/hosts/ethiopia_production
@@ -1,24 +1,8 @@
-[ethiopia_production:children]
-servers
-postgres
-redis
-monitoring
-storage
-load_balancing
-
-[postgres:children]
-postgres_primary
-postgres_secondary
-
 [postgres_primary]
 197.156.66.181 replication_role=primary
 
 [postgres_secondary]
 197.156.66.178 replication_role=replica
-
-[servers:children]
-webservers
-sidekiq
 
 [webservers]
 197.156.66.181
@@ -28,19 +12,11 @@ sidekiq
 197.156.66.181
 197.156.66.178
 
-[redis:children]
-redis_primary
-redis_secondary
-
 [redis_primary]
 197.156.66.181
 
 [redis_secondary]
 197.156.66.178
-
-[monitoring:children]
-prometheus
-grafana
 
 [prometheus]
 197.156.66.181
@@ -54,3 +30,28 @@ grafana
 [load_balancing]
 197.156.66.181
 197.156.66.178
+
+# Server groups. You do not need to change them.
+[ethiopia_production:children]
+servers
+postgres
+redis
+monitoring
+storage
+load_balancing
+
+[postgres:children]
+postgres_primary
+postgres_secondary
+
+[servers:children]
+webservers
+sidekiq
+
+[redis:children]
+redis_primary
+redis_secondary
+
+[monitoring:children]
+prometheus
+grafana


### PR DESCRIPTION
**Story card:** [sc-7970](https://app.shortcut.com/simpledotorg/story/7970/create-generator-for-new-deployment)

This PR adds a `bin/new` generator script to the standalone repo. Given a deployment name and subdomain, it can create the necessary files to get a new instance up and running.

### Question

Do you think we should collect the server IPs in this script as well, wizard-ize the full creation of the inventory file?

**YES** I've updated the PR to collect IPs (or leave them blank and configure later) for maximum convenience.

### Sample

```
Enter the name of the new deployment.
The deployment name can only contain letters and underscores, eg: 'test_environment'.
Deployment name: test

Enter the domain or subdomain on which you'd like to host your Simple server instance
Eg. api.simple.org
Domain/Subdomain: test

Enter the public IP addresses of the servers or VMs that will host the following services.
If you don't have the IP addresses yet, you can leave these fields blank, and configure them later.
Primary postgres database: 1.1.1.1
Secondary postgres database (hot standby follower): 1.1.1.2
Web servers (comma-separated list): 1.1.1.3
Sidekiq background job servers (comma-separated list): 1.1.1.4,1.1.1.5
Primary Redis cache: 1.1.1.6
Secondary Redis cache (hot standby follower): 1.1.1.7
Prometheus (system monitoring tool): 1.1.1.8
Grafana (dashboards for viewing Prometheus data): 1.1.1.9
Storage of application logs, audit logs, and database backups: 2.2.2.2
Load balancer (this server will be the entry point for all incoming web traffic): 2.2.2.5

Would you like to generate an Ansible vault password for this deployment? Select No if you already have an Ansible
vault password that you plan to use
Generate Ansible vault password? (y/N): y

Created /Users/hariharanmohanraj/code/simple/simple-standalone/hosts/test...
Created /Users/hariharanmohanraj/code/simple/simple-standalone/group_vars/test/vars.yml...
Created /Users/hariharanmohanraj/code/simple/simple-standalone/group_vars/test/vault.yml.decrypted...
Updated /Users/hariharanmohanraj/code/simple/simple-standalone/ansible.cfg...
Created /Users/hariharanmohanraj/.vault_password_test...

test deployment environment initialized!
To finish setup, follow these steps
- If you skipped entering any IP addresses, enter them into your Ansible inventory file hosts/test
- Configure your instance's variables in group_vars/test/vars.yml
- Configure your instance's secrets in group_vars/test/vault.yml.decrypted
- Create your vault file by running `make encrypt hosts=test`

And you're done! You can then deploy Simple onto your servers with `make all hosts=test`
```