### PR TITLE
Add missing sections from old standalone README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 An Ansible collection for running [Simple Server](https://github.com/simpledotorg/simple-server) on virtual machines.
 
+[Overview of standalone architecture](docs/architecture.md)
+
 ## Getting Started
+
+### Install local requirements
+```bash
+brew install rbenv
+rbenv install 2.7.4
+brew install ansible@2.8.3 gnu-tar
+make init
+```
 
 ### Add a new deployment
 
@@ -19,6 +29,21 @@ This script will prompt you for some key information about your new deployment:
 
 and generate the necessary files for you. Once complete, the script will provide you with instructions on how to install
 Simple on your new servers.
+
+#### Setup SSH on servers
+
+You will need to setup SSH access to a remote user with [NOPASSWD](https://linuxhint.com/setup-sudo-no-password-linux/) sudo access on the servers.
+We recommend using the username `ubuntu`. You can configure this to something else in [`ansible.cfg`](/standalone/ansible/ansible.cfg).
+To setup this user, you can run this on each server:
+```
+$ adduser ubuntu
+$ sudo visudo
+# At the end of the file add
+ubuntu     ALL=(ALL) NOPASSWD:ALL
+```
+Note: AWS ec2 instances already come with an `ubuntu` sudoer.
+
+Setup your SSH keys on the server for the `ubuntu` user. Make sure you can establish an SSH connection to your server as `ubuntu`.
 
 ### Edit vault secrets
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,25 @@
+## Simple Standalone Architecture
+
+### Components
+
+The Simple Server setup managed by this tooling has the following components.
+
+| Component                          | Purpose | Technologies |
+| ---------                          | ------- | ------------ |
+| Primary relational database        | Primary application database | [PostgreSQL](https://www.postgresql.org/) |
+| Secondary relational database      | Follower application database | [PostgreSQL](https://www.postgresql.org/) |
+| Primary non-relational datastore   | Datastore for application caching and background jobs | [Redis](https://redis.io/) |
+| Secondary non-relational datastore | Follower for primary non-relational datastore | [Redis](https://redis.io/) |
+| Web servers                        | Dashboard web application and APIs | [Ruby on Rails](https://rubyonrails.org/)<br>[Passenger](https://www.phusionpassenger.com/) |
+| Background processing servers      | Perform enqueued tasks asynchronously | [Sidekiq](https://github.com/mperham/sidekiq) |
+| Load balancer                      | Route incoming web requests across web servers | [HAProxy](http://www.haproxy.org/) |
+| System health monitoring           | Monitor the system health of all Simple servers | [Prometheus](https://prometheus.io/)<br>[Grafana](https://grafana.com/) |
+| Storage                            | Large storage location for logs and database backups | [`rsync`](https://linux.die.net/man/1/rsync) |
+
+### Topography
+
+These components are arranged in the following topography.
+
+![topography](https://docs.google.com/drawings/d/e/2PACX-1vTr2ryR_vqxAtdNCzKxn1pIdz3b57be8j3iHAVBEDBGstA6jGqOX6deyoXeWBXEk_yzeybFsmrzm5Ww/pub?w=960&amp;h=720)
+
+If this image is out-of-date, you can edit it [here](https://docs.google.com/drawings/d/1jHZeW141ivRUAWhHEduwlyasFxNzZ1Nk2V_AQ12w4p8/edit).


### PR DESCRIPTION
**Story card:** -

## Because

Some parts of the README got removed in https://github.com/simpledotorg/deployment/pull/424.

## This addresses

Adds back the missing README sections.