### PR TITLE
Doc

### DIFF
--- a/docs/ethiopia/ethiopia-ssl-certificates.md
+++ b/docs/ethiopia/ethiopia-ssl-certificates.md
@@ -15,7 +15,7 @@ sudo service nginx stop
 sudo service haproxy stop
 ```
 
-Generate a standalone certificate on the server
+Generate a standalone certificate on the server. (for Example, for simple.moh.gov.et domain)
 
 ```bash
 sudo certbot certonly --standalone -d simple.moh.gov.et
@@ -53,14 +53,11 @@ cd ~/simple-standalone
 Decrypt the `vault.yml`
 
 ```bash
-# cd standalone/ansible/roles/load_balancing/vars
 cd group_vars/<deployment>/
-# ansible-vault decrypt --vault-id ~/.vault_password_et ssl-vault.yml
 ansible-vault decrypt --vault-id ~/.vault_password_et vault.yml
 ```
 For Example
 ```bash
-# cd standalone/ansible/roles/load_balancing/vars
 cd group_vars/ethiopia_demo/
 ansible-vault decrypt --vault-id ~/.vault_password_et vault.yml
 ```
@@ -69,7 +66,7 @@ Add(Change) the newly generated fullchain and private key files to the decrypted
 
 ```yml
 ssl_cert_files:
-  simple-demo.moh.gov.et:  '//This is for simple-demo renewal and for the production use the simple.moh.gov.et section:'
+  simple-demo.moh.gov.et:  #'//This is for simple-demo renewal and for the production use the simple.moh.gov.et section:'
     certificate_chain: |
     <Contents of the new fullchain.pem>
   private_key: | 
@@ -98,7 +95,6 @@ Open a pull request in Github with your changes. The Simple team will accept you
 In the meantime, you don't have to wait. You can immediately install the new certificate on Simple Server from the deployment repository.
 
 ```bash
-# make update-ssl-certs hosts=ethiopia/demo
 make update-ssh-keys hosts=<deployment>   
 ```
 For example

--- a/docs/ethiopia/ethiopia-ssl-certificates.md
+++ b/docs/ethiopia/ethiopia-ssl-certificates.md
@@ -40,49 +40,55 @@ cat /etc/letsencrypt/live/simple.moh.gov.et/fullchain.pem
 Fetch the latest updates to the deployment repository.
 
 ```bash
-cd ~/deployment
+cd ~/simple-standalone
 git checkout master
 git pull --rebase origin master
 ```
-
-Decrypt the `ssl-vault.yml`
-
+Or if you don't have the clone of the simple-standalone repo on your local machine, 
 ```bash
-cd standalone/ansible/roles/load_balancing/vars
-ansible-vault decrypt --vault-id ~/.vault_password_et ssl-vault.yml
+git https://github.com/simpledotorg/simple-standalone.git
+cd ~/simple-standalone
 ```
 
-Add the new fullchain and private key files to the decrypted ssl-vault.yml
+Decrypt the `vault.yml`
+
+```bash
+# cd standalone/ansible/roles/load_balancing/vars
+cd group_vars/<deployment>/
+# ansible-vault decrypt --vault-id ~/.vault_password_et ssl-vault.yml
+ansible-vault decrypt --vault-id ~/.vault_password_et vault.yml
+```
+For Example
+```bash
+# cd standalone/ansible/roles/load_balancing/vars
+cd group_vars/ethiopia_demo/
+ansible-vault decrypt --vault-id ~/.vault_password_et vault.yml
+```
+
+Add(Change) the newly generated fullchain and private key files to the decrypted vault.yml
 
 ```yml
 ssl_cert_files:
-  /etc/ssl/simple.moh.gov.et.crt:
-    owner: root
-    group: root
-    mode: "u=r,go="
-    content: |
+  simple-demo.moh.gov.et:  '//This is for simple-demo renewal and for the production use the simple.moh.gov.et section:'
+    certificate_chain: |
     <Contents of the new fullchain.pem>
-  /etc/ssl/simple.moh.gov.et.key:
-    owner: root
-    group: root
-    mode: "u=r,go="
-    content: |
-    <Contents of the new privkey.pem>
+  private_key: | 
+    <Contents of the new privkey.pem> 
 ```
 
-Re-encrypt the `ssl-vault.yml`
+Re-encrypt the `vault.yml`
 
 ```bash
-ansible-vault encrypt --vault-id ~/.vault_password_et ssl-vault.yml
+ansible-vault encrypt --vault-id ~/.vault_password_et vault.yml
 ```
 
-Commit and push your updates. **Caution: Be sure to re-encrypt the `ssl-vault.yml` before commiting your changes!**
+Commit and push your updates. **Caution: Be sure to re-encrypt the `vault.yml` before commiting your changes!**
 
 ```bash
-cd ~/deployment
-git add standalone/ansible/roles/load_balancing/vars/ssl-vault.yml
-git commit -m 'Update SSL certificate'
-git push siraj master
+cd ~/simple-standalone
+git add group_vars/<deployment>/vault.yml
+git commit -m 'SSL certificate is renewed until date'
+git push yourbranch master
 ```
 
 Open a pull request in Github with your changes. The Simple team will accept your changes in a few days.
@@ -92,5 +98,10 @@ Open a pull request in Github with your changes. The Simple team will accept you
 In the meantime, you don't have to wait. You can immediately install the new certificate on Simple Server from the deployment repository.
 
 ```bash
-make update-ssl-certs hosts=ethiopia/demo
+# make update-ssl-certs hosts=ethiopia/demo
+make update-ssh-keys hosts=<deployment>   
+```
+For example
+```
+make update-ssh-keys hosts=ethiopia_demo
 ```


### PR DESCRIPTION
**Story card:** [sc-8984](https://app.shortcut.com/simpledotorg/story/8984/update-simple-standalone-doc)

## Because

When moving from deployment to Simple-standalone repo, some docs like [ethiopia-ssl-certificates](https://github.com/simpledotorg/simple-standalone/blob/master/docs/ethiopia/ethiopia-ssl-certificates.md) require some amendments.

## This addresses

Correct deployment steps for Simple-standalone 
## Test instructions

Enter detailed instructions for how to test this PR...