### PR TITLE
Install the latest version of fwupd

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -19,6 +19,7 @@
       - build-essential
       - cron
       - fail2ban
+      - fwupd
       - git-core
       - htop
       - less


### PR DESCRIPTION
**Story card:** [sc-10663](https://app.shortcut.com/simpledotorg/story/10663/reduce-the-noise-in-ethiopia-alerts-channel)

## Because

We get too many alerts on #ethiopia-alerts which makes the channel noisy.

## This addresses

Upgrades the fwupd service which was failing due to a know systemd issue

## Test instructions

`sudo systemctl restart fwupd-refresh.service` should exit successfully. 