### PR TITLE
update semaphore CI agent machine

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,8 +2,8 @@ version: v1.0
 name: Start
 agent:
   machine:
-    type: e1-standard-2
-    os_image: ubuntu1804
+    type: e2-standard-2
+    os_image: ubuntu2204
 blocks:
   - name: Checkout
     task:

--- a/.semaphore/update_ethiopia_demo_config.yml
+++ b/.semaphore/update_ethiopia_demo_config.yml
@@ -18,5 +18,5 @@ blocks:
           - ssh-add ~/.ssh/semaphore_id_rsa
 agent:
   machine:
-    type: e1-standard-2
-    os_image: ubuntu1804
+    type: e2-standard-2
+    os_image: ubuntu2204

--- a/.semaphore/update_ethiopia_production_config.yml
+++ b/.semaphore/update_ethiopia_production_config.yml
@@ -18,5 +18,5 @@ blocks:
           - ssh-add ~/.ssh/semaphore_id_rsa
 agent:
   machine:
-    type: e1-standard-2
-    os_image: ubuntu1804
+    type: e2-standard-2
+    os_image: ubuntu2204


### PR DESCRIPTION
Ubuntu 18.04 images have been deprecated by Semaphore.
