### PR TITLE
Turn on hot_standby_feedback for primary and replica

### DIFF
--- a/roles/postgres_replication/vars/main.yml
+++ b/roles/postgres_replication/vars/main.yml
@@ -4,5 +4,7 @@ replication_config_primary:
   - {name: wal_level, value: replica, regex: '#?wal_level = \w+(\s+#.*)'}
   - {name: max_wal_senders, value: 3, regex: '#?max_wal_senders = \d+(\s+#.*)'}
   - {name: wal_keep_size, value: 1024, regex: '#?wal_keep_size = .*(\s+#.*)'}
+  - {name: hot_standby_feedback, value: on, regex: '^#?hot_standby_feedback = \w+(\s+#.*)'}
 replication_config_replica:
   - {name: hot_standby, value: on, regex: '^#?hot_standby = \w+(\s+#.*)'}
+  - {name: hot_standby_feedback, value: on, regex: '^#?hot_standby_feedback = \w+(\s+#.*)'}


### PR DESCRIPTION
**Story card:** [sc-13796](https://app.shortcut.com/simpledotorg/story/13796/patient-line-list-returning-no-data-in-simple-dashboard-ethiopia)

## Because

Database queries take a while to run because the constituent query parts get retired mid-flight.

## This addresses

Turning `hot_standby_feedback` on for main and replica

## Test instructions

n/a
