### PR TITLE
Fix Postgres Deployments

### DIFF
--- a/group_vars/postgres.yml
+++ b/group_vars/postgres.yml
@@ -2,9 +2,9 @@
 postgres:
   locale: "en_US.UTF-8"
   pg_hba:
-    - {contype: local, databases: all, users: postgres, method: peer}
+    # - {contype: local, databases: all, users: postgres, method: peer}
     - {contype: host,  databases: all, users: all, source: all, method: md5}
-    - {contype: local, databases: all, users: all, source: all, method: md5}
+    # - {contype: local, databases: all, users: all, source: all, method: md5}
 
 postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
 postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"

--- a/group_vars/postgres.yml
+++ b/group_vars/postgres.yml
@@ -2,9 +2,7 @@
 postgres:
   locale: "en_US.UTF-8"
   pg_hba:
-    # - {contype: local, databases: all, users: postgres, method: peer}
     - {contype: host,  databases: all, users: all, source: all, method: md5}
-    # - {contype: local, databases: all, users: all, source: all, method: md5}
 
 postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
 postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"


### PR DESCRIPTION
**Story card:** [sc-13796](https://app.shortcut.com/simpledotorg/story/13796/patient-line-list-returning-no-data-in-simple-dashboard-ethiopia)

## Because

We cannot use local connection types when setting up hosts

```
TASK [postgres : Grant the default permisions for pg_hba conf.] *************************************************************************************************************
failed: [primary] (item={'contype': 'local', 'databases': 'all', 'users': 'postgres', 'method': 'peer'}) => {"ansible_loop_var": "item", "changed": false, "item": {"contype": "local", "databases": "all", "method": "peer", "users": "postgres"}, "msg": "Error modifying rules:\nRule can't contain an address and netmask if the connection-type is 'local'"}
failed: [replica] (item={'contype': 'local', 'databases': 'all', 'users': 'postgres', 'method': 'peer'}) => {"ansible_loop_var": "item", "changed": false, "item": {"contype": "local", "databases": "all", "method": "peer", "users": "postgres"}, "msg": "Error modifying rules:\nRule can't contain an address and netmask if the connection-type is 'local'"}
ok: [primary] => (item={'contype': 'host', 'databases': 'all', 'users': 'all', 'source': 'all', 'method': 'md5'})
ok: [replica] => (item={'contype': 'host', 'databases': 'all', 'users': 'all', 'source': 'all', 'method': 'md5'})
failed: [primary] (item={'contype': 'local', 'databases': 'all', 'users': 'all', 'source': 'all', 'method': 'md5'}) => {"ansible_loop_var": "item", "changed": false, "item": {"contype": "local", "databases": "all", "method": "md5", "source": "all", "users": "all"}, "msg": "Error modifying rules:\nRule can't contain an address and netmask if the connection-type is 'local'"}
failed: [replica] (item={'contype': 'local', 'databases': 'all', 'users': 'all', 'source': 'all', 'method': 'md5'}) => {"ansible_loop_var": "item", "changed": false, "item": {"contype": "local", "databases": "all", "method": "md5", "source": "all", "users": "all"}, "msg": "Error modifying rules:\nRule can't contain an address and netmask if the connection-type is 'local'"}
```

## This addresses

Connection types for PostgreSQL playbook

## Test instructions

n/a
