### PR TITLE
Fix hot-standby-feedback value

### DIFF
--- a/roles/postgres_replication/vars/main.yml
+++ b/roles/postgres_replication/vars/main.yml
@@ -4,7 +4,7 @@ replication_config_primary:
   - {name: wal_level, value: replica, regex: '#?wal_level = \w+(\s+#.*)'}
   - {name: max_wal_senders, value: 3, regex: '#?max_wal_senders = \d+(\s+#.*)'}
   - {name: wal_keep_size, value: 1024, regex: '#?wal_keep_size = .*(\s+#.*)'}
-  - {name: hot_standby_feedback, value: on, regex: '^#?hot_standby_feedback = \w+(\s+#.*)'}
+  - {name: hot_standby_feedback, value: 'on', regex: '^#?hot_standby_feedback = \w+(\s+#.*)'}
 replication_config_replica:
-  - {name: hot_standby, value: on, regex: '^#?hot_standby = \w+(\s+#.*)'}
-  - {name: hot_standby_feedback, value: on, regex: '^#?hot_standby_feedback = \w+(\s+#.*)'}
+  - {name: hot_standby, value: 'on', regex: '^#?hot_standby = \w+(\s+#.*)'}
+  - {name: hot_standby_feedback, value: 'on', regex: '^#?hot_standby_feedback = \w+(\s+#.*)'}


### PR DESCRIPTION
**Story card:** [sc-13796](https://app.shortcut.com/simpledotorg/story/13796/patient-line-list-returning-no-data-in-simple-dashboard-ethiopia)

## Because

For some reason, Ansible seems to translate  `on` as `True` in the PostgreSQL config.

## This addresses

Using a string `"on"` instead

## Test instructions

This is an experiment to see if it works. If it doesn't work after a deploy, this would be reverted
