### PR TITLE
Use Rails as task-runner

### DIFF
--- a/roles/simple-server/hooks/after_symlink.yml
+++ b/roles/simple-server/hooks/after_symlink.yml
@@ -19,7 +19,7 @@
       - test
 
 - name: precompile assets
-  command: "{{ bundle_path }} exec rake assets:precompile"
+  command: "RAILS_ENV=production ./bin/rails assets:precompile"
   args:
     chdir: "{{ ansistrano_release_path.stdout }}"
 
@@ -32,13 +32,13 @@
 
 - name: load schema
   when: schema_loaded.rc != 0
-  command: "{{ bundle_path }} exec rake db:schema:load"
+  command: "RAILS_ENV=production ./bin/rails db:schema:load"
   run_once: true
   args:
     chdir: "{{ ansistrano_release_path.stdout }}"
 
 - name: migrate the db
-  command: "{{ bundle_path }} exec rake db:migrate:with_data"
+  command: "RAILS_ENV=production ./bin/rails db:migrate:with_data"
   run_once: true
   args:
     chdir: "{{ ansistrano_release_path.stdout }}"


### PR DESCRIPTION
**Story card:** [sc-14556](https://app.shortcut.com/simpledotorg/story/14556/prefer-rails-to-rake-for-task-runner)

## Because

`bundle exec rake [anything]` fails on the box

## This addresses

Switching the task runner from `rake` to `./bin/rails`

## Test instructions

n/a
