### PR TITLE
Increasing metabase timeout to 10 mins for ethiopia

### DIFF
--- a/roles/load_balancing/templates/haproxy.cfg.j2
+++ b/roles/load_balancing/templates/haproxy.cfg.j2
@@ -77,6 +77,11 @@ backend alertmanager
 
 backend metabase
     http-request set-path %[path,regsub(^/metabase/?,/)]
+{% if haproxy_version == '1.4' %}
+    srvtimeout 600s
+{% else %}
+    timeout server 600s
+{% endif %}
 {% for server in groups.metabase %}
     server alertmanager{{ loop.index }} {{ server }}:{{ metabase_port }}
 {% endfor %}


### PR DESCRIPTION
**Story card:** [sc-14484](https://app.shortcut.com/simpledotorg/story/14484/medication-titration-report-not-working-ethiopia)

## Because

Metabase reports were not giving results, as requests were timing out after 50 secs, which is too less for these types of reports.

## This addresses

Increasing timeout for metabase to 10 mins, which is same as Bangladesh and SL. 

## Test instructions

After deployment, check on metabase if titration reports are working.