### PR TITLE
fix: Set the environment variables the Ansible way

### DIFF
--- a/roles/simple-server/hooks/after_symlink.yml
+++ b/roles/simple-server/hooks/after_symlink.yml
@@ -19,9 +19,11 @@
       - test
 
 - name: precompile assets
-  command: "RAILS_ENV=production ./bin/rails assets:precompile"
+  command: "./bin/rails assets:precompile"
   args:
     chdir: "{{ ansistrano_release_path.stdout }}"
+  environment:
+    RAILS_ENV: production
 
 - name: check if schema has been loaded
   shell: |
@@ -32,16 +34,20 @@
 
 - name: load schema
   when: schema_loaded.rc != 0
-  command: "RAILS_ENV=production ./bin/rails db:schema:load"
+  command: "./bin/rails db:schema:load"
   run_once: true
   args:
     chdir: "{{ ansistrano_release_path.stdout }}"
+  environment:
+    RAILS_ENV: production
 
 - name: migrate the db
-  command: "RAILS_ENV=production ./bin/rails db:migrate:with_data"
+  command: "./bin/rails db:migrate:with_data"
   run_once: true
   args:
     chdir: "{{ ansistrano_release_path.stdout }}"
+  environment:
+    RAILS_ENV: production
 
 - name: update the crontab
   command: "{{ bundle_path }} exec whenever --update-crontab simple-server --set environment=production"


### PR DESCRIPTION
**Story card:** [sc-15051](https://app.shortcut.com/simpledotorg/story/15051/semaphore-failure-in-ethiopia)

## Because

Deployments in ET are failing because of #69

## This addresses

This change ensures that we set environment variables the way Ansible
expects they be set. We still want to keep `rails` as the task runner
here, since `rake` is has been phased out.

## Test instructions

Do a deployment
