### PR TITLE
fix: Use bundled Rails

### DIFF
--- a/roles/simple-server/hooks/after_symlink.yml
+++ b/roles/simple-server/hooks/after_symlink.yml
@@ -19,7 +19,7 @@
       - test
 
 - name: precompile assets
-  command: "./bin/rails assets:precompile"
+  command: "{{ bundle_path }} exec rails assets:precompile"
   args:
     chdir: "{{ ansistrano_release_path.stdout }}"
   environment:
@@ -34,7 +34,7 @@
 
 - name: load schema
   when: schema_loaded.rc != 0
-  command: "./bin/rails db:schema:load"
+  command: "{{ bundle_path }} exec rails db:schema:load"
   run_once: true
   args:
     chdir: "{{ ansistrano_release_path.stdout }}"
@@ -42,7 +42,7 @@
     RAILS_ENV: production
 
 - name: migrate the db
-  command: "./bin/rails db:migrate:with_data"
+  command: "{{ bundle_path }} exec rails db:migrate:with_data"
   run_once: true
   args:
     chdir: "{{ ansistrano_release_path.stdout }}"


### PR DESCRIPTION
**Story card:** [sc-15051](https://app.shortcut.com/simpledotorg/story/15051/semaphore-failure-in-ethiopia)

## Because

…one does not just simply use `./bin/rails` with our deployment setup. 

— why? That's a discussion for a different PR

## This addresses

Using the Rails which ships in the bundle

## Test instructions

Do a deployment
