### PR TITLE
sc-15228 Upgraging ruby & bundler versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An Ansible collection for running [Simple Server](https://github.com/simpledotor
 ### Install local requirements
 ```bash
 brew install rbenv
-rbenv install 2.7.4
+rbenv install 2.7.8
 brew install ansible@2.8 gnu-tar
 make init
 ```

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,8 +1,8 @@
 ---
 ansible_port: 22
 deploy_user: "deploy"
-ruby_version: "2.7.4"
-bundler_version: "2.3.22"
+ruby_version: "2.7.8"
+bundler_version: "2.4.22"
 app_name: "simple-server"
 rbenv_root: "/home/{{ deploy_user }}/.rbenv"
 bundle_path: "{{ rbenv_root }}/shims/bundle"


### PR DESCRIPTION
Ruby 2.7.4 is an older patch version and may contain bugs or security vulnerabilities that have been addressed in later 2.7.x releases. Upgrading to Ruby 2.7.8 ensures we are using the most stable and secure version within the 2.7 series, while maintaining compatibility with existing application code

This addresses
Upgrades the Ruby version from 2.7.4 to 2.7.8.

Updates any relevant Dockerfiles, CI configurations, or .ruby-version files to reflect the new version.

Ensures compatibility with dependencies and existing application code under Ruby 2.7.8

Test instructions
bundle exec rspec