### PR TITLE
Add patient scoring setup for Ethiopia production and demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,6 @@ restart-passenger: ##@Utilities Restart passenger
 
 restart-sidekiq: ##@Utilities Restart sidekiq
 	ansible-playbook deploy.yml -i hosts/$(hosts) -l sidekiq --tags restart-sidekiq
+
+patient-scoring: ##@Setup Setup patient scoring on hosts
+	ansible-playbook patient_scoring.yml -i hosts/$(hosts)

--- a/all.yml
+++ b/all.yml
@@ -8,3 +8,4 @@
 - import_playbook: monitoring.yml
 - import_playbook: logshipping.yml
 - import_playbook: datadog.yml
+- import_playbook: patient_scoring.yml

--- a/hosts/ethiopia_demo
+++ b/hosts/ethiopia_demo
@@ -33,6 +33,9 @@
 [metabase]
 157.245.99.197
 
+[patient_scoring]
+167.71.226.153
+
 # Server groups. You do not need to change them.
 [ethiopia_demo:children]
 servers

--- a/hosts/ethiopia_production
+++ b/hosts/ethiopia_production
@@ -33,6 +33,9 @@
 [metabase]
 197.156.66.178
 
+[patient_scoring]
+197.156.66.181
+
 # Server groups. You do not need to change them.
 [ethiopia_production:children]
 servers

--- a/patient_scoring.yml
+++ b/patient_scoring.yml
@@ -1,0 +1,5 @@
+---
+- hosts: patient_scoring
+  roles:
+    - { role: patient-scoring, tags: ['patient-scoring'] }
+  remote_user: "{{ deploy_user }}"

--- a/roles/patient-scoring/tasks/main.yml
+++ b/roles/patient-scoring/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+- name: Ensure Docker is installed
+  apt:
+    name:
+      - docker.io
+      - docker-compose
+    state: present
+  become: true
+
+- name: Ensure Docker service is running
+  service:
+    name: docker
+    state: started
+    enabled: yes
+  become: true
+
+- name: Add deploy user to docker group
+  user:
+    name: "{{ deploy_user }}"
+    groups: docker
+    append: yes
+  become: true
+
+- name: Create patient-scoring directory
+  file:
+    path: /home/{{ deploy_user }}/patient-scoring
+    state: directory
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_user }}"
+  become: true
+
+- name: Copy patient scoring script
+  template:
+    src: patient_scoring.sh.j2
+    dest: /home/{{ deploy_user }}/patient-scoring/patient_scoring.sh
+    mode: "0755"
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_user }}"
+  become: true
+
+- name: Pull patient scoring Docker image
+  command: docker pull {{ patient_scoring_image }}
+  become: true
+  changed_when: true
+
+- name: Setup cron job for patient scoring
+  cron:
+    name: "patient scoring"
+    minute: "{{ patient_scoring_cron_minute }}"
+    hour: "{{ patient_scoring_cron_hour }}"
+    day: "{{ patient_scoring_cron_day }}"
+    job: "/home/{{ deploy_user }}/patient-scoring/patient_scoring.sh >> /home/{{ deploy_user }}/patient-scoring/patient_scoring.log 2>&1"
+    user: "{{ deploy_user }}"
+  become: true

--- a/roles/patient-scoring/templates/patient_scoring.sh.j2
+++ b/roles/patient-scoring/templates/patient_scoring.sh.j2
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Patient Scoring Script for {{ deploy_env }}
+# Runs train.sh and scoring.sh inside Docker container
+
+set -e
+
+CONTAINER_NAME="patient-scoring-{{ deploy_env }}"
+IMAGE="{{ patient_scoring_image }}"
+DB_HOST="{{ groups['postgres_primary'] | first }}"
+DB_NAME="{{ database_name }}"
+DB_USER="{{ database.username }}"
+DB_PASSWORD='{{ database.password }}'
+DATABASE_URL="postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:5432/${DB_NAME}"
+
+echo "$(date): Starting patient scoring job for {{ deploy_env }}"
+
+# Pull latest image
+echo "$(date): Pulling latest image"
+docker pull $IMAGE
+
+# Run train.sh
+echo "$(date): Running train.sh"
+docker run --rm \
+  --name "${CONTAINER_NAME}-train" \
+  --network host \
+  -e DATABASE_URL="${DATABASE_URL}" \
+  $IMAGE \
+  ./train.sh
+
+echo "$(date): train.sh completed"
+
+# Run scoring.sh
+echo "$(date): Running scoring.sh"
+docker run --rm \
+  --name "${CONTAINER_NAME}-scoring" \
+  --network host \
+  -e DATABASE_URL="${DATABASE_URL}" \
+  $IMAGE \
+  ./scoring.sh
+
+echo "$(date): scoring.sh completed"
+echo "$(date): Patient scoring job finished successfully"

--- a/roles/patient-scoring/vars/main.yml
+++ b/roles/patient-scoring/vars/main.yml
@@ -1,0 +1,5 @@
+---
+patient_scoring_image: "simpledotorg/simple_patient_scoring:main"
+patient_scoring_cron_minute: "0"
+patient_scoring_cron_hour: "0"
+patient_scoring_cron_day: "*/15"


### PR DESCRIPTION
- Create patient-scoring Ansible role with Docker-based cron job
- Add patient_scoring host group to Ethiopia production and demo
- Add patient_scoring.yml playbook
- Add make target for patient-scoring
- Include in all.yml for full deployments

**Story card:** [SIMPLEETH-31](https://rtsl.atlassian.net/browse/SIMPLEETH-31)

## Because

 Ethiopia environments (production and demo) need patient scoring capability to identify high-risk patients, similar to other deployments like Bangladesh, India, and Sri Lanka.

## This addresses

- Sets up patient scoring infrastructure for Ethiopia using Ansible (VM-based deployment)
  - Creates a Docker-based cron job that runs train.sh and scoring.sh every 15 days
  - Adds patient scoring to both Ethiopia production and Ethiopia demo environments
  - Aligns Ethiopia with other country deployments that already have patient scoring enabled

## Test instructions

Enter detailed instructions for how to test this PR...