### PR TITLE
adding host name to pstgres command

### DIFF
--- a/roles/simple-server/hooks/after_symlink.yml
+++ b/roles/simple-server/hooks/after_symlink.yml
@@ -27,7 +27,7 @@
 
 - name: check if schema has been loaded
   shell: |
-    echo "\d+" | PGPASSWORD={{ database.password | quote }} psql -d {{ database_name | quote }} -U {{ database.username | quote }} | grep ar_internal_metadata
+    echo "\d+" | PGPASSWORD={{ database.password | quote }} psql -h {{ groups.postgres_primary | first }} -d {{ database_name | quote }} -U {{ database.username | quote }} | grep ar_internal_metadata
   register: schema_loaded
   ignore_errors: true
   run_once: true


### PR DESCRIPTION
**Story card:** [SIMPLEBACK-123](https://rtsl.atlassian.net/browse/SIMPLEBACK-123)

## Because

Deployments on ET demo are not going through

## This addresses

The problem was that the psql command in the check if schema has been loaded task was missing the -h (host) flag, so it was attempting to connect to a local PostgreSQL instance on the web server instead of the remote PostgreSQL primary server.
Added -h {{ groups.postgres_primary | first }} to the psql command to specify the correct PostgreSQL server.

## Test instructions

Enter detailed instructions for how to test this PR...