### PR TITLE
fixing rbenv rehash issue

### DIFF
--- a/roles/rbenv/tasks/main.yml
+++ b/roles/rbenv/tasks/main.yml
@@ -65,6 +65,13 @@
   become: true
   become_user: "{{ deploy_user }}"
 
+- name: clean up stale rbenv shim file
+  file:
+    path: "/home/{{ deploy_user }}/.rbenv/shims/.rbenv-shim"
+    state: absent
+  become: true
+  become_user: "{{ deploy_user }}"
+
 - name: rbenv rehash
   shell: rbenv rehash
   environment:


### PR DESCRIPTION
**Story card:** [SIMPLEBACK-123](https://rtsl.atlassian.net/browse/SIMPLEBACK-123)

## Because

Deployment on ET failed
https://simple.semaphoreci.com/jobs/9c283069-511e-43b5-8ce8-9b5828dfa9b4
The `rbenv rehash` command was failing on one server because a stale .rbenv-shim file existed in /home/deploy/.rbenv/shims/, which rbenv was unable to clean up automatically.

## This addresses

Added a new task that removes this stale file before attempting the rehash operation. This ensures a clean rehash process on every deployment.

## Test instructions

NA